### PR TITLE
Fix gcov dump call on Linux

### DIFF
--- a/R/load-dev.R
+++ b/R/load-dev.R
@@ -25,7 +25,11 @@ covr_flags <- function() {
 
     # LDFLAGS is ignored on windows and visa versa
     LDFLAGS = if (!is_windows()) {
-      "--coverage"
+      if (is_linux()) {
+        "--coverage -Wl,--whole-archive -lgcov -Wl,--no-whole-archive"
+      } else {
+        "--coverage"
+      }
     } else {
       NULL
     },

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,6 +64,10 @@ is_windows <- function() {
   .Platform$OS.type == "windows"
 }
 
+is_linux <- function() {
+  tolower(Sys.info()[["sysname"]]) == "linux"
+}
+
 zero <- function(x) {
   as.character(ifelse(x == 0, "", x))
 }


### PR DESCRIPTION
Need to link to gcov.a specially so it keeps
the `gcov_dump` and `gcov_reset` symbols.